### PR TITLE
Rails 7.1 Incompatibility: ActionView::Helpers::FormBuilder

### DIFF
--- a/meta_request/Dockerfile-rails-7.1
+++ b/meta_request/Dockerfile-rails-7.1
@@ -1,0 +1,36 @@
+FROM ruby:3.0-alpine
+
+RUN apk add --update --no-cache \
+        build-base \
+        curl-dev \
+        git \
+        nodejs \
+        shared-mime-info \
+        sqlite-dev \
+        tzdata \
+        yaml-dev \
+        yarn \
+        zlib-dev
+
+RUN mkdir /app /gem
+WORKDIR /app
+
+RUN gem update --system 3.5.7
+RUN bundle config force_ruby_platform true
+RUN gem install rails -v 7.1.3.2
+RUN rails new .
+
+COPY . /gem
+RUN bundle add meta_request --path /gem
+RUN bundle install
+
+COPY res/routes.rb /app/config/
+COPY res/dummy_controller.rb /app/app/controllers/
+COPY res/dummy /app/app/views/dummy
+COPY res/meta_request_test.rb /app/test/integration/
+
+RUN bundle exec rails db:migrate
+
+ENV PARALLEL_WORKERS 1
+
+CMD ["bin/rake"]

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -65,9 +65,11 @@ module MetaRequest
     end
 
     def not_encodable?(value)
-      (defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)) ||
-        (defined?(ActionDispatch) &&
-          (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response)))
+      return true if defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+      return true if defined?(ActionDispatch) && (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response))
+      return true if defined?(ActionView) && value.is_a?(ActionView::Helpers::FormBuilder)
+
+      false
     end
 
     # https://gist.github.com/dbenhur/1070399


### PR DESCRIPTION
Due to Rails monkey patching the Object#to_json method, it is possible for an unassuming object to call the method and trigger a <SystemStackError: stack level too deep> error.

https://github.com/rails/rails/blob/v7.1.3.2/activesupport/lib/active_support/core_ext/object/json.rb#L63

We discovered a case where this was caused by an instance of ActionView::Helpers::FormBuilder. We extended MetaRequest::Event#not_encodable? to exclude this class and prevent the recursion.